### PR TITLE
fix(versions): render new {name,view,download} datasheet link objects

### DIFF
--- a/layouts/versions/list.html
+++ b/layouts/versions/list.html
@@ -2,10 +2,22 @@
   KiCad "versions" section list template, two modes:
   - Project page (content/versions/<P>/_index.md): header with the latest
     version's thumbnail + name + description (README body), a collapsible
-    Documentation section listing the datasheet filenames (front-matter
-    data emitted by kproj), then a per-version tab strip.
+    Documentation section listing curated datasheets (front-matter data
+    emitted by kproj), then a per-version tab strip.
   - Top /versions/ index: one card per project (latest thumbnail).
   Tabs are dependency-free CSS :target (+ :has() default).
+
+  Datasheet entry shapes in `.Params.datasheets` (kproj#29 / kproj ADR 0010
+  deep-linked the shared SPCoast-inventory library instead of copying PDFs
+  per project; the older per-project-copy shape lingers on pages that
+  haven't been republished yet, so both are rendered here):
+  - New (kproj >= the deep-link change): a map per entry -
+    {name, view, download} - name is the curated Datasheet Name, view/
+    download are absolute URLs into the public SPCoast-inventory repo.
+  - Legacy: a bare filename string; rendered as a local
+    /versions/<project>/datasheets/<file> link (the old per-project-copy
+    path). Only still-published, not-yet-republished pages carry this
+    shape - kproj no longer writes it.
 */}}
 {{ define "main" }}
 {{ $versions := sort (where .Pages "Params.publish" true) "Params.board_rev" "desc" }}
@@ -28,7 +40,15 @@
   <details class="documentation">
     <summary>Documentation &mdash; {{ len . }} datasheet{{ if ne (len .) 1 }}s{{ end }}</summary>
     <ul class="datasheet-list">
-      {{ range . }}<li><a href="{{ (printf "/versions/%s/datasheets/%s" $.Params.project .) | relURL }}">{{ . }}</a></li>{{ end }}
+      {{ range . }}
+        {{ if reflect.IsMap . }}
+          {{/* New shape: deep-link the shared SPCoast-inventory library (view + download). */}}
+          <li><a href="{{ .view }}">{{ .name }}</a> (<a href="{{ .download }}">download</a>)</li>
+        {{ else }}
+          {{/* Legacy shape: bare filename, once copied under /versions/<project>/datasheets/. */}}
+          <li><a href="{{ (printf "/versions/%s/datasheets/%s" $.Params.project .) | relURL }}">{{ . }}</a></li>
+        {{ end }}
+      {{ end }}
     </ul>
   </details>
   {{ end }}


### PR DESCRIPTION
Companion PR for plocher/kproj#29.

## Summary
kproj#29 changed kproj's published Datasheet Name links from a flat list of bare filenames (each copied into /versions/<P>/datasheets/ and linked locally) to a deep-link into the shared, curated plocher/SPCoast-inventory library repo: front-matter datasheets: is now a list of {name, view, download} maps, and kproj no longer copies any PDFs into the site.

layouts/versions/list.html still expected the old flat-string shape and built a dead local URL — a path that no longer exists once a project republishes under the new kproj (see kproj PR plocher/kproj#35's adversarial review, blocking finding #1).

## What changed
- layouts/versions/list.html's Documentation section now uses reflect.IsMap to detect which shape a given datasheets entry carries:
  - New (map): renders a view link + a download link — deep-links the shared library.
  - Legacy (string): unchanged — the old local /versions/<P>/datasheets/<file> link, so already-published pages from other projects that haven't been republished yet keep working.

## Validation
Local hugo build (v0.163.3) against a temporary fixture (not committed) carrying one entry of each shape in the same list — both rendered correctly and the build reported no errors.

## Coordination
This PR should merge together with plocher/kproj#35 (the human ticket owner is coordinating the merge).